### PR TITLE
Initialize Actix identity provider with Mongo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "identity-provider"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4"
+mongodb = { version = "2", features = ["tokio-runtime", "chrono-0_4"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+jsonwebtoken = "8"
+uuid = { version = "1", features = ["serde", "v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+dotenvy = "0.15"
+argon2 = "0.5"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# identity-provider
+# Identity Provider
+
+Rust-based identity provider using Actix Web and MongoDB.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,21 @@
+use std::env;
+use dotenvy::dotenv;
+
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+    pub mongodb_uri: String,
+    pub jwt_secret: String,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        dotenv().ok();
+        Self {
+            host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".into()),
+            port: env::var("PORT").unwrap_or_else(|_| "8080".into()).parse().unwrap(),
+            mongodb_uri: env::var("MONGODB_URI").expect("MONGODB_URI must be set"),
+            jwt_secret: env::var("JWT_SECRET").expect("JWT_SECRET must be set"),
+        }
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,6 @@
+use mongodb::{Client, Database};
+
+pub async fn init_db(uri: &str) -> mongodb::error::Result<Database> {
+    let client = Client::with_uri_str(uri).await?;
+    Ok(client.database("identity"))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,35 @@
+mod config;
+mod db;
+mod models;
+mod routes;
+mod token;
+
+use actix_web::{App, HttpServer, web};
+use config::Config;
+use db::init_db;
+use mongodb::Database;
+
+pub struct AppState {
+    pub db: Database,
+    pub jwt_secret: String,
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let cfg = Config::from_env();
+    let db = init_db(&cfg.mongodb_uri).await.expect("failed to connect to db");
+    let state = web::Data::new(AppState {
+        db,
+        jwt_secret: cfg.jwt_secret.clone(),
+    });
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(state.clone())
+            .service(routes::auth::register)
+            .service(routes::auth::login)
+    })
+    .bind((cfg.host, cfg.port))?
+    .run()
+    .await
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+use mongodb::bson::{doc, oid::ObjectId, DateTime};
+use mongodb::Database;
+use argon2::{Argon2, PasswordHasher, PasswordVerifier};
+use argon2::password_hash::{SaltString, PasswordHash};
+use rand_core::OsRng;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct User {
+    #[serde(rename = "_id")]
+    pub id: ObjectId,
+    pub email: String,
+    pub hashed_password: String,
+    pub created_at: DateTime,
+}
+
+#[derive(Deserialize)]
+pub struct RegisterRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+impl User {
+    pub async fn create(db: &Database, email: String, password: String) -> mongodb::error::Result<Self> {
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        let hashed = argon2.hash_password(password.as_bytes(), &salt).unwrap().to_string();
+
+        let user = User {
+            id: ObjectId::new(),
+            email,
+            hashed_password: hashed,
+            created_at: DateTime::now(),
+        };
+
+        let collection = db.collection::<User>("users");
+        collection.insert_one(&user, None).await?;
+        Ok(user)
+    }
+
+    pub async fn find_by_email(db: &Database, email: &str) -> mongodb::error::Result<Option<User>> {
+        let collection = db.collection::<User>("users");
+        collection.find_one(doc! {"email": email}, None).await
+    }
+
+    pub fn verify_password(&self, password: &str) -> bool {
+        let parsed_hash = PasswordHash::new(&self.hashed_password).unwrap();
+        Argon2::default().verify_password(password.as_bytes(), &parsed_hash).is_ok()
+    }
+}

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,0 +1,26 @@
+use actix_web::{post, web, HttpResponse, Responder};
+use crate::{models::{RegisterRequest, LoginRequest, User}, token, AppState};
+
+#[post("/auth/register")]
+pub async fn register(state: web::Data<AppState>, payload: web::Json<RegisterRequest>) -> impl Responder {
+    let req = payload.into_inner();
+    match User::create(&state.db, req.email, req.password).await {
+        Ok(_) => HttpResponse::Created().finish(),
+        Err(err) => {
+            eprintln!("register error: {err:?}");
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}
+
+#[post("/auth/login")]
+pub async fn login(state: web::Data<AppState>, payload: web::Json<LoginRequest>) -> impl Responder {
+    let req = payload.into_inner();
+    match User::find_by_email(&state.db, &req.email).await {
+        Ok(Some(user)) if user.verify_password(&req.password) => {
+            let token = token::generate(&user.id, &state.jwt_secret);
+            HttpResponse::Ok().json(serde_json::json!({"token": token}))
+        }
+        _ => HttpResponse::Unauthorized().finish(),
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,27 @@
+use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey};
+use serde::{Serialize, Deserialize};
+use chrono::{Utc, Duration};
+use mongodb::bson::oid::ObjectId;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub exp: usize,
+}
+
+pub fn generate(user_id: &ObjectId, secret: &str) -> String {
+    let expiration = Utc::now()
+        .checked_add_signed(Duration::hours(1))
+        .expect("valid timestamp")
+        .timestamp() as usize;
+    let claims = Claims {
+        sub: user_id.to_hex(),
+        exp: expiration,
+    };
+    encode(&Header::default(), &claims, &EncodingKey::from_secret(secret.as_ref())).unwrap()
+}
+
+pub fn validate(token: &str, secret: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
+    decode::<Claims>(token, &DecodingKey::from_secret(secret.as_ref()), &Validation::default())
+        .map(|data| data.claims)
+}


### PR DESCRIPTION
## Summary
- bootstrap Actix Web service using MongoDB for user storage
- implement registration and login endpoints with JWT issuance
- add configuration loader and token utilities

## Testing
- `cargo test` *(fails: failed to download from crates.io - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895831e71fc832dae66a9569a93298b