### PR TITLE
Add CI pipeline and Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: actions/setup-rust@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --locked --all
 
   build:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+      - name: Run tests
+        run: cargo test --all
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t identity-provider .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Multi-stage Dockerfile using Alpine
+FROM rust:1-alpine AS builder
+WORKDIR /usr/src/app
+# Install build dependencies
+RUN apk add --no-cache musl-dev openssl-dev pkgconfig
+# Copy source
+COPY . .
+# Build release binary
+RUN cargo build --release
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates
+WORKDIR /usr/local/bin
+COPY --from=builder /usr/src/app/target/release/identity-provider .
+CMD ["./identity-provider"]


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and build container
- provide multi-stage Dockerfile based on Alpine

## Testing
- `cargo test` *(fails: failed to download from crates.io: 403)*
- `docker build -t identity-provider .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689595a816f8832d8a85443a15dc3bc5